### PR TITLE
Integer statements

### DIFF
--- a/libraries/analysis-javascript/lib/type/resolving/TypeEnum.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeEnum.ts
@@ -20,6 +20,8 @@ import { ElementType } from "../discovery/element/Element";
 
 export enum TypeEnum {
   NUMERIC = "numeric",
+  INTEGER = "integer", // decimal?
+
   STRING = "string",
   BOOLEAN = "boolean",
   NULL = "null",

--- a/libraries/analysis-javascript/lib/type/resolving/TypeModel.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeModel.ts
@@ -131,6 +131,10 @@ export class TypeModel {
     if (!this._typeExecutionScoreMap.get(id).has(type)) {
       this._typeExecutionScoreMap.get(id).set(type, 0);
     }
+
+    if (type === TypeEnum.NUMERIC) {
+      this.addTypeScore(id, TypeEnum.INTEGER, score);
+    }
   }
 
   addProperty(element: string, property: string, id: string) {
@@ -221,6 +225,7 @@ export class TypeModel {
         TypeEnum.FUNCTION,
         TypeEnum.NULL,
         TypeEnum.NUMERIC,
+        TypeEnum.INTEGER,
         TypeEnum.OBJECT,
         TypeEnum.REGEX,
         TypeEnum.STRING,
@@ -274,6 +279,7 @@ export class TypeModel {
         TypeEnum.FUNCTION,
         TypeEnum.NULL,
         TypeEnum.NUMERIC,
+        TypeEnum.INTEGER,
         TypeEnum.OBJECT,
         TypeEnum.REGEX,
         TypeEnum.STRING,

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
@@ -52,6 +52,7 @@ import { JavaScriptTestCaseSampler } from "./JavaScriptTestCaseSampler";
 import { TargetType } from "@syntest/analysis";
 import { ObjectFunctionCall } from "../statements/action/ObjectFunctionCall";
 import { ObjectType } from "@syntest/analysis-javascript";
+import { IntegerStatement } from "../statements/primitive/IntegerStatement";
 
 export class JavaScriptRandomSampler extends JavaScriptTestCaseSampler {
   private _rootContext: RootContext;
@@ -628,6 +629,9 @@ export class JavaScriptRandomSampler extends JavaScriptTestCaseSampler {
       case "numeric": {
         return this.sampleNumber(id, name);
       }
+      case "integer": {
+        return this.sampleInteger(id, name);
+      }
       case "null": {
         return this.sampleNull(id, name);
       }
@@ -814,6 +818,20 @@ export class JavaScriptRandomSampler extends JavaScriptTestCaseSampler {
       TypeEnum.NUMERIC,
       prng.uniqueId(),
       prng.nextDouble(min, max)
+    );
+  }
+
+  sampleInteger(id: string, name: string): IntegerStatement {
+    // by default we create small numbers (do we need very large numbers?)
+    const max = 10;
+    const min = -10;
+
+    return new IntegerStatement(
+      id,
+      name,
+      TypeEnum.INTEGER,
+      prng.uniqueId(),
+      prng.nextInt(min, max)
     );
   }
 

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
@@ -35,6 +35,7 @@ import { UndefinedStatement } from "../statements/primitive/UndefinedStatement";
 import { ArrowFunctionStatement } from "../statements/complex/ArrowFunctionStatement";
 import { ArrayStatement } from "../statements/complex/ArrayStatement";
 import { ObjectStatement } from "../statements/complex/ObjectStatement";
+import { IntegerStatement } from "../statements/primitive/IntegerStatement";
 
 /**
  * JavaScriptRandomSampler class
@@ -146,6 +147,7 @@ export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScri
   abstract sampleNull(id: string, name: string): NullStatement;
 
   abstract sampleNumber(id: string, name: string): NumericStatement;
+  abstract sampleInteger(id: string, name: string): IntegerStatement;
 
   abstract sampleUndefined(id: string, name: string): UndefinedStatement;
 

--- a/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ *
+ * This file is part of SynTest Framework - SynTest Javascript.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { prng } from "@syntest/search";
+
+import { JavaScriptTestCaseSampler } from "../../sampling/JavaScriptTestCaseSampler";
+
+import { PrimitiveStatement } from "./PrimitiveStatement";
+import { Statement } from "../Statement";
+
+/**
+ * Generic number class
+ *
+ * @author Dimitri Stallenberg
+ */
+export class IntegerStatement extends PrimitiveStatement<number> {
+  constructor(
+    id: string,
+    name: string,
+    type: string,
+    uniqueId: string,
+    value: number
+  ) {
+    super(id, name, type, uniqueId, Math.round(value));
+    this._classType = "IntegerStatement";
+  }
+
+  mutate(sampler: JavaScriptTestCaseSampler, depth: number): Statement {
+    if (prng.nextBoolean(sampler.resampleGeneProbability)) {
+      return sampler.sampleArgument(depth + 1, this.id, this.name);
+    }
+
+    if (prng.nextBoolean(sampler.deltaMutationProbability)) {
+      return this.deltaMutation(sampler);
+    }
+
+    return sampler.sampleInteger(this.id, this.name);
+  }
+
+  deltaMutation(sampler: JavaScriptTestCaseSampler): IntegerStatement {
+    // small mutation
+    const change = prng.nextGaussian(0, 20);
+
+    let newValue = Math.round(this.value + change);
+
+    // If illegal values are not allowed we make sure the value does not exceed the specified bounds
+    if (!sampler.exploreIllegalValues) {
+      const max = Number.MAX_SAFE_INTEGER;
+      const min = Number.MIN_SAFE_INTEGER;
+
+      if (newValue > max) {
+        newValue = max;
+      } else if (newValue < min) {
+        newValue = min;
+      }
+    }
+
+    return new IntegerStatement(
+      this.id,
+      this.name,
+      this.type,
+      prng.uniqueId(),
+      newValue
+    );
+  }
+
+  copy(): IntegerStatement {
+    return new IntegerStatement(
+      this.id,
+      this.name,
+      this.type,
+      prng.uniqueId(),
+      this.value
+    );
+  }
+
+  getFlatTypes(): string[] {
+    return ["integer"];
+  }
+}


### PR DESCRIPTION
Currently, we only have a statement for the JavaScript Numeric type, which encompasses integers and decimals. However, most problems will require integers and not doubles. Using the numeric type makes it much more challenging to satisfy certain branches.

This PR adds an integer type next to the default numeric type so that the search algorithm can figure out which type works better.