### PR TITLE
Lock babel types package version

### DIFF
--- a/libraries/analysis-javascript/lib/target/export/ExpressionStatement.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExpressionStatement.ts
@@ -56,15 +56,19 @@ export function extractExportsFromAssignmentExpression(
     );
   }
 
-  partialExport = checkExportAndDefault(visitor, right);
+  if (left.isLVal()) {
+    partialExport = checkExportAndDefault(visitor, right);
 
-  if (partialExport) {
-    return extractExportsFromRightAssignmentExpression(
-      visitor,
-      filePath,
-      left,
-      partialExport
-    );
+    if (partialExport) {
+      return extractExportsFromRightAssignmentExpression(
+        visitor,
+        filePath,
+        left,
+        partialExport
+      );
+    }
+  } else {
+    // no clue
   }
 
   return [];

--- a/libraries/analysis-javascript/package.json
+++ b/libraries/analysis-javascript/package.json
@@ -62,6 +62,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/types": "^7.21.5"
+    "@babel/types": "7.23.0"
   }
 }

--- a/libraries/ast-visitor-javascript/package.json
+++ b/libraries/ast-visitor-javascript/package.json
@@ -58,6 +58,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/types": "^7.21.5"
+    "@babel/types": "7.23.0"
   }
 }

--- a/libraries/instrumentation-javascript/package.json
+++ b/libraries/instrumentation-javascript/package.json
@@ -55,7 +55,7 @@
     "istanbul-lib-coverage": "^3.2.0"
   },
   "devDependencies": {
-    "@babel/types": "^7.21.5",
+    "@babel/types": "7.23.0",
     "@types/babel__core": "7.20.0"
   },
   "engines": {

--- a/libraries/search-javascript/package.json
+++ b/libraries/search-javascript/package.json
@@ -72,6 +72,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/types": "^7.21.5"
+    "@babel/types": "7.23.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "@syntest/search": "^0.5.0-beta.3"
       },
       "devDependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "7.23.0"
       },
       "engines": {
         "node": ">=10.24.0"
@@ -124,7 +124,7 @@
         "globals": "^13.20.0"
       },
       "devDependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "7.23.0"
       },
       "engines": {
         "node": ">=10.24.0"
@@ -181,7 +181,7 @@
         "istanbul-lib-coverage": "^3.2.0"
       },
       "devDependencies": {
-        "@babel/types": "^7.21.5",
+        "@babel/types": "7.23.0",
         "@types/babel__core": "7.20.0"
       },
       "engines": {
@@ -250,7 +250,7 @@
         "regenerator-runtime": "0.13.9"
       },
       "devDependencies": {
-        "@babel/types": "^7.21.5"
+        "@babel/types": "7.23.0"
       },
       "engines": {
         "node": ">=10.24.0"
@@ -2200,12 +2200,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-      "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.19",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {


### PR DESCRIPTION
There is a new version, so installing a new package would create a mismatch in the babel/types versions