### PR TITLE
Adjust repo to rename of the framework

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,9 +31,9 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Building
-      - name: Core - Build
+      - name: SynTest - Build
         run: npm run build

--- a/.github/workflows/main-quality.yml
+++ b/.github/workflows/main-quality.yml
@@ -31,13 +31,13 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Formatting
-      - name: Core - Run Formatter
+      - name: SynTest - Run Formatter
         run: npm run format:check
 
       # Linting
-      - name: Core - Run Linter
+      - name: SynTest - Run Linter
         run: npm run lint

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -31,16 +31,16 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Testing
-      - name: Core - Run Tests
+      - name: SynTest - Run Tests
         # Generate lcov.info file
         run: npm run test:coverage:ci
 
       # Artifact
-      - name: Core - Upload Test Results
+      - name: SynTest - Upload Test Results
         uses: actions/upload-artifact@v3
         with:
           name: coverage-results

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -44,9 +44,9 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Building
-      - name: Core - Build
+      - name: SynTest - Build
         run: npm run build

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -29,13 +29,13 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Formatting
-      - name: Core - Run Formatter
+      - name: SynTest - Run Formatter
         run: npm run format:check
 
       # Linting
-      - name: Core - Run Linter
+      - name: SynTest - Run Linter
         run: npm run lint

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,17 +51,17 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Testing
-      - name: Core - Run Tests
+      - name: SynTest - Run Tests
         id: test
         # Generate lcov.info file and Mocha test report
         run: npm run test:coverage:ci
 
       # Artifact
-      - name: Core - Upload Test Results
+      - name: SynTest - Upload Test Results
         if: ${{ matrix.report_coverage }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -45,22 +45,22 @@ jobs:
           git config --global user.email 'info@syntest.org'
         
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Building
-      - name: Core - Build
+      - name: SynTest - Build
         run: npm run build
 
       # Versioning
-      - name: "Core - Version"
+      - name: SynTest - Version
         env:
           GH_TOKEN: ${{ secrets.SYNTEST_CI }}
         run: |
           npx lerna version --conventional-commits --conventional-prerelease --changelog-preset conventionalcommits --preid beta --no-changelog --yes --loglevel silly
       
       # Publishing
-      - name: "Core - Publish"
+      - name: SynTest - Publish
         env:
           GH_TOKEN: ${{ secrets.SYNTEST_CI }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,21 +36,21 @@ jobs:
           git config --global user.email 'info@syntest.org'
 
       # Dependencies
-      - name: Core - Install Dependencies
+      - name: SynTest - Install Dependencies
         run: npm ci
 
       # Building
-      - name: Core - Build
+      - name: SynTest - Build
         run: npm run build
 
       # Versioning
-      - name: "Core - Version"
+      - name: SynTest - Version
         env:
           GH_TOKEN: ${{ secrets.SYNTEST_CI }}
         run: npx lerna version --conventional-commits --conventional-graduate --changelog-preset conventionalcommits --create-release github --yes --loglevel silly
 
       # Publishing
-      - name: "Core - Publish"
+      - name: SynTest - Publish
         env:
           GH_TOKEN: ${{ secrets.SYNTEST_CI }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SynTest JavaScript is a tool for automatically generating test cases for the Jav
 
 ### Overview
 
-The common core contains the common interfaces for the code control-flow representation, test case structure, genes, and the implementation for the meta-heuristic search algorithms.
+The framework contains the common interfaces for the code control-flow representation, test case structure, genes, and the implementation for the meta-heuristic search algorithms.
 
 ## Installation
 

--- a/libraries/analysis-javascript/lib/RootContext.ts
+++ b/libraries/analysis-javascript/lib/RootContext.ts
@@ -19,7 +19,7 @@
 import { existsSync, lstatSync } from "node:fs";
 
 import * as t from "@babel/types";
-import { RootContext as CoreRootContext } from "@syntest/analysis";
+import { RootContext as FrameworkRootContext } from "@syntest/analysis";
 import { getLogger, Logger } from "@syntest/logging";
 import TypedEmitter from "typed-emitter";
 
@@ -42,7 +42,7 @@ import { TypeModelFactory } from "./type/resolving/TypeModelFactory";
 import { TypePool } from "./type/resolving/TypePool";
 import { readFile } from "./utils/fileSystem";
 
-export class RootContext extends CoreRootContext<t.Node> {
+export class RootContext extends FrameworkRootContext<t.Node> {
   protected static LOGGER: Logger;
 
   protected _exportFactory: ExportFactory;

--- a/libraries/analysis-javascript/lib/ast/AbstractSyntaxTreeFactory.ts
+++ b/libraries/analysis-javascript/lib/ast/AbstractSyntaxTreeFactory.ts
@@ -18,12 +18,12 @@
 
 import { transformSync } from "@babel/core";
 import * as t from "@babel/types";
-import { AbstractSyntaxTreeFactory as CoreAbstractSyntaxTreeFactory } from "@syntest/analysis";
+import { AbstractSyntaxTreeFactory as FrameworkAbstractSyntaxTreeFactory } from "@syntest/analysis";
 
 import { defaultBabelOptions } from "./defaultBabelConfig";
 
 export class AbstractSyntaxTreeFactory
-  implements CoreAbstractSyntaxTreeFactory<t.Node>
+  implements FrameworkAbstractSyntaxTreeFactory<t.Node>
 {
   convert(filepath: string, source: string): t.Node {
     const options: unknown = JSON.parse(JSON.stringify(defaultBabelOptions));

--- a/libraries/analysis-javascript/lib/cfg/ControlFlowGraphFactory.ts
+++ b/libraries/analysis-javascript/lib/cfg/ControlFlowGraphFactory.ts
@@ -17,7 +17,7 @@
  */
 import { traverse } from "@babel/core";
 import * as t from "@babel/types";
-import { ControlFlowGraphFactory as CoreControlFlowGraphFactory } from "@syntest/analysis";
+import { ControlFlowGraphFactory as FrameworkControlFlowGraphFactory } from "@syntest/analysis";
 import { contractControlFlowProgram, ControlFlowProgram } from "@syntest/cfg";
 
 import { Factory } from "../Factory";
@@ -26,7 +26,7 @@ import { ControlFlowGraphVisitor } from "./ControlFlowGraphVisitor";
 
 export class ControlFlowGraphFactory
   extends Factory
-  implements CoreControlFlowGraphFactory<t.Node>
+  implements FrameworkControlFlowGraphFactory<t.Node>
 {
   convert(filePath: string, AST: t.Node): ControlFlowProgram {
     const visitor = new ControlFlowGraphVisitor(filePath, this.syntaxForgiving);

--- a/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
+++ b/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
@@ -18,7 +18,7 @@
 
 import { traverse } from "@babel/core";
 import * as t from "@babel/types";
-import { DependencyFactory as CoreDependencyFactory } from "@syntest/analysis";
+import { DependencyFactory as FrameworkDependencyFactory } from "@syntest/analysis";
 
 import { Factory } from "../Factory";
 
@@ -31,7 +31,7 @@ import { DependencyVisitor } from "./DependencyVisitor";
  */
 export class DependencyFactory
   extends Factory
-  implements CoreDependencyFactory<t.Node>
+  implements FrameworkDependencyFactory<t.Node>
 {
   /**
    * Generate function map for specified target.

--- a/libraries/analysis-javascript/lib/target/Target.ts
+++ b/libraries/analysis-javascript/lib/target/Target.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2021 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest Javascript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,20 @@
  * limitations under the License.
  */
 import {
-  SubTarget as CoreSubTarget,
-  Target as CoreTarget,
+  SubTarget as FrameworkSubTarget,
+  Target as FrameworkTarget,
   TargetType,
 } from "@syntest/analysis";
 
 import { VisibilityType } from "./VisibilityType";
 
-export interface Target extends CoreTarget {
+export interface Target extends FrameworkTarget {
   path: string;
   name: string;
   subTargets: SubTarget[];
 }
 
-export interface SubTarget extends CoreSubTarget {
+export interface SubTarget extends FrameworkSubTarget {
   type: TargetType;
   id: string;
 }

--- a/libraries/analysis-javascript/lib/target/TargetFactory.ts
+++ b/libraries/analysis-javascript/lib/target/TargetFactory.ts
@@ -20,7 +20,7 @@ import * as path from "node:path";
 
 import { traverse } from "@babel/core";
 import * as t from "@babel/types";
-import { TargetFactory as CoreTargetFactory } from "@syntest/analysis";
+import { TargetFactory as FrameworkTargetFactory } from "@syntest/analysis";
 
 import { Factory } from "../Factory";
 
@@ -35,7 +35,7 @@ import { TargetVisitor } from "./TargetVisitor";
  */
 export class TargetFactory
   extends Factory
-  implements CoreTargetFactory<t.Node>
+  implements FrameworkTargetFactory<t.Node>
 {
   /**
    * Generate function map for specified target.

--- a/libraries/search-javascript/README.md
+++ b/libraries/search-javascript/README.md
@@ -10,7 +10,7 @@ SynTest JavaScript is a tool for automatically generating test cases for the Jav
 
 ### Overview
 
-The common core contains the common interfaces for the code control-flow representation, test case structure, genes, and the implementation for the meta-heuristic search algorithms.
+The framework contains the common interfaces for the code control-flow representation, test case structure, genes, and the implementation for the meta-heuristic search algorithms.
 
 ## Installation
 

--- a/libraries/search-javascript/lib/criterion/BranchDistance.ts
+++ b/libraries/search-javascript/lib/criterion/BranchDistance.ts
@@ -20,13 +20,13 @@ import { transformSync, traverse } from "@babel/core";
 import { defaultBabelOptions } from "@syntest/analysis-javascript";
 import { getLogger, Logger } from "@syntest/logging";
 import {
-  BranchDistance as CoreBranchDistance,
+  BranchDistance as FrameworkBranchDistance,
   shouldNeverHappen,
 } from "@syntest/search";
 
 import { BranchDistanceVisitor } from "./BranchDistanceVisitor";
 
-export class BranchDistance extends CoreBranchDistance {
+export class BranchDistance extends FrameworkBranchDistance {
   protected static LOGGER: Logger;
   protected syntaxForgiving: boolean;
   protected stringAlphabet: string;

--- a/link.sh
+++ b/link.sh
@@ -1,9 +1,9 @@
 # this file is used for local development
-# it links the syntest-core libraries to the syntest-javascript libraries
+# it links the syntest-framework libraries to the syntest-javascript libraries
 
 # NOTE: we cannot simply delete the entire @syntest folder since there are always local syntest-javascript dependencies here
 
-# core libraries
+# framework libraries
 
 rm -rf node_modules/@syntest/analysis
 rm -rf node_modules/@syntest/cfg
@@ -15,15 +15,14 @@ rm -rf node_modules/@syntest/search
 rm -rf node_modules/@syntest/storage
 rm -rf node_modules/@syntest/prng
 
-# core plugins
-rm -rf node_modules/@syntest/plugin-core-event-listener-graphing
-rm -rf node_modules/@syntest/plugin-core-event-listener-state-storage
-rm -rf node_modules/@syntest/plugin-core-event-listener-websocket
-rm -rf node_modules/@syntest/plugin-core-metric-middleware-file-writer
-rm -rf node_modules/@syntest/plugin-core-metric-middleware-statistics
-rm -rf node_modules/@syntest/plugin-core-search-algorithm-experimental
+# framework plugins
+rm -rf node_modules/@syntest/plugin-event-listener-state-storage
+rm -rf node_modules/@syntest/plugin-event-listener-websocket
+rm -rf node_modules/@syntest/plugin-metric-middleware-file-writer
+rm -rf node_modules/@syntest/plugin-metric-middleware-statistics
+rm -rf node_modules/@syntest/plugin-search-algorithm-experimental
 
-# core tools
+# framework tools
 rm -rf node_modules/@syntest/base-language
 rm -rf node_modules/@syntest/cli
 rm -rf node_modules/@syntest/init
@@ -31,26 +30,25 @@ rm -rf node_modules/@syntest/init
 
 cd node_modules/@syntest
 
-# core libraries
-ln -s ../../../syntest-core/libraries/analysis analysis
-ln -s ../../../syntest-core/libraries/cfg cfg
-ln -s ../../../syntest-core/libraries/cli-graphics cli-graphics
-ln -s ../../../syntest-core/libraries/logging logging
-ln -s ../../../syntest-core/libraries/metric metric
-ln -s ../../../syntest-core/libraries/module module
-ln -s ../../../syntest-core/libraries/search search
-ln -s ../../../syntest-core/libraries/storage storage
-ln -s ../../../syntest-core/libraries/prng prng
+# framework libraries
+ln -s ../../../syntest-framework/libraries/analysis analysis
+ln -s ../../../syntest-framework/libraries/cfg cfg
+ln -s ../../../syntest-framework/libraries/cli-graphics cli-graphics
+ln -s ../../../syntest-framework/libraries/logging logging
+ln -s ../../../syntest-framework/libraries/metric metric
+ln -s ../../../syntest-framework/libraries/module module
+ln -s ../../../syntest-framework/libraries/search search
+ln -s ../../../syntest-framework/libraries/storage storage
+ln -s ../../../syntest-framework/libraries/prng prng
 
-# core plugins
-ln -s ../../../syntest-core/plugins/plugin-core-event-listener-graphing plugin-core-event-listener-graphing
-ln -s ../../../syntest-core/plugins/plugin-core-event-listener-state-storage plugin-core-event-listener-state-storage
-ln -s ../../../syntest-core/plugins/plugin-core-event-listener-websocket plugin-core-event-listener-websocket
-ln -s ../../../syntest-core/plugins/plugin-core-metric-middleware-file-writer plugin-core-metric-middleware-file-writer
-ln -s ../../../syntest-core/plugins/plugin-core-metric-middleware-statistics plugin-core-metric-middleware-statistics
-ln -s ../../../syntest-core/plugins/plugin-core-search-algorithm-experimental plugin-core-search-algorithm-experimental
+# framework plugins
+ln -s ../../../syntest-framework/plugins/plugin-event-listener-state-storage plugin-event-listener-state-storage
+ln -s ../../../syntest-framework/plugins/plugin-event-listener-websocket plugin-event-listener-websocket
+ln -s ../../../syntest-framework/plugins/plugin-metric-middleware-file-writer plugin-metric-middleware-file-writer
+ln -s ../../../syntest-framework/plugins/plugin-metric-middleware-statistics plugin-metric-middleware-statistics
+ln -s ../../../syntest-framework/plugins/plugin-search-algorithm-experimental plugin-search-algorithm-experimental
 
-# core tools
-ln -s ../../../syntest-core/tools/cli cli
-ln -s ../../../syntest-core/tools/base-language base-language
-ln -s ../../../syntest-core/tools/init init
+# framework tools
+ln -s ../../../syntest-framework/tools/cli cli
+ln -s ../../../syntest-framework/tools/base-language base-language
+ln -s ../../../syntest-framework/tools/init init

--- a/plugins/plugin-javascript-event-listener-state-storage/CHANGELOG.md
+++ b/plugins/plugin-javascript-event-listener-state-storage/CHANGELOG.md
@@ -3,6 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.0](https://github.com/syntest-framework/syntest-core/compare/@syntest/plugin-javascript-event-listener-state-storage@0.1.0-beta.1...@syntest/plugin-javascript-event-listener-state-storage@0.1.0) (2023-09-19)
+## [0.1.0](https://github.com/syntest-framework/syntest-javascript/compare/@syntest/plugin-javascript-event-listener-state-storage@0.1.0-beta.1...@syntest/plugin-javascript-event-listener-state-storage@0.1.0) (2023-09-19)
 
 **Note:** Version bump only for package @syntest/plugin-javascript-event-listener-state-storage

--- a/plugins/plugin-javascript-event-listener-state-storage/LICENSE.header.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/LICENSE.header.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-<%= YEAR %> Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-javascript-event-listener-state-storage/NOTICE
+++ b/plugins/plugin-javascript-event-listener-state-storage/NOTICE
@@ -1,4 +1,4 @@
-SynTest Framework - SynTest Core
+SynTest Framework - SynTest JavaScript
 Copyright 2020-2023 Delft University of Technology and SynTest contributors
 
 This product includes software developed at

--- a/plugins/plugin-javascript-event-listener-state-storage/README.md
+++ b/plugins/plugin-javascript-event-listener-state-storage/README.md
@@ -1,1 +1,1 @@
-# State Storage plugin for the SynTest Core.
+# State Storage plugin for the SynTest JavaScript.

--- a/plugins/plugin-javascript-event-listener-state-storage/index.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/index.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorage.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorage.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageModule.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageModule.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/plugin-javascript-event-listener-state-storage/package.json
+++ b/plugins/plugin-javascript-event-listener-state-storage/package.json
@@ -8,7 +8,7 @@
   ],
   "homepage": "https://www.syntest.org",
   "bugs": {
-    "url": "https://github.com/syntest-framework/syntest-core/issues"
+    "url": "https://github.com/syntest-framework/syntest-javascript/issues"
   },
   "license": "Apache-2.0",
   "contributors": [
@@ -29,7 +29,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/syntest-framework/syntest-core.git"
+    "url": "git+https://github.com/syntest-framework/syntest-javascript.git"
   },
   "scripts": {
     "build": "tsc --build",

--- a/plugins/plugin-javascript-event-listener-state-storage/test/simulation.test.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/test/simulation.test.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/javascript/lib/JavaScriptModule.ts
+++ b/tools/javascript/lib/JavaScriptModule.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/javascript/lib/commands/test.ts
+++ b/tools/javascript/lib/commands/test.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
+++ b/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
+++ b/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright 2020-2023 Delft University of Technology and SynTest contributors
  *
- * This file is part of SynTest Framework - SynTest Core.
+ * This file is part of SynTest Framework - SynTest JavaScript.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As the `syntest-core` repository has been renamed to `syntest-framework` (See https://github.com/syntest-framework/syntest-framework/pull/382), some references here had to be updated as well.