### PR TITLE
Remove author tags

### DIFF
--- a/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
+++ b/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
@@ -26,8 +26,6 @@ import { DependencyVisitor } from "./DependencyVisitor";
 
 /**
  * Dependency generator for targets.
- *
- * @author Dimitri Stallenberg
  */
 export class DependencyFactory
   extends Factory

--- a/libraries/analysis-javascript/lib/target/TargetFactory.ts
+++ b/libraries/analysis-javascript/lib/target/TargetFactory.ts
@@ -30,8 +30,6 @@ import { TargetVisitor } from "./TargetVisitor";
 
 /**
  * TargetFactory for Javascript.
- *
- * @author Dimitri Stallenberg
  */
 export class TargetFactory
   extends Factory

--- a/libraries/analysis-javascript/lib/target/VisibilityType.ts
+++ b/libraries/analysis-javascript/lib/target/VisibilityType.ts
@@ -18,7 +18,5 @@
 
 /**
  * Visibility Types.
- *
- * @author Dimitri Stallenberg
  */
 export type VisibilityType = "public" | "private" | "protected";

--- a/libraries/analysis-javascript/lib/target/export/ExportFactory.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExportFactory.ts
@@ -26,8 +26,6 @@ import { ExportVisitor } from "./ExportVisitor";
 
 /**
  * ExportFactory for Javascript.
- *
- * @author Dimitri Stallenberg
  */
 export class ExportFactory extends Factory {
   /**

--- a/libraries/analysis-javascript/lib/type/resolving/TypeModelFactory.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeModelFactory.ts
@@ -23,8 +23,6 @@ import { TypeModel } from "./TypeModel";
 
 /**
  * Abstract TypeResolver class
- *
- * @author Dimitri Stallenberg
  */
 export abstract class TypeModelFactory {
   /**

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
@@ -51,8 +51,6 @@ import { SetterGenerator } from "./generators/action/SetterGenerator";
 
 /**
  * JavaScriptRandomSampler class
- *
- * @author Dimitri Stallenberg
  */
 export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScriptTestCase> {
   private _rootContext: RootContext;

--- a/libraries/search-javascript/lib/testcase/statements/Statement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/Statement.ts
@@ -21,9 +21,6 @@ import { Encoding, EncodingSampler } from "@syntest/search";
 
 import { ContextBuilder } from "../../testbuilding/ContextBuilder";
 
-/**
- * @author Dimitri Stallenberg
- */
 export abstract class Statement {
   private _variableIdentifier: string;
   private _typeIdentifier: string;

--- a/libraries/search-javascript/lib/testcase/statements/action/ConstantObject.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ConstantObject.ts
@@ -25,9 +25,6 @@ import { Decoding } from "../Statement";
 
 import { ActionStatement } from "./ActionStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class ConstantObject extends ActionStatement {
   constructor(
     variableIdentifier: string,

--- a/libraries/search-javascript/lib/testcase/statements/action/FunctionCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/FunctionCall.ts
@@ -25,9 +25,6 @@ import { Decoding, Statement } from "../Statement";
 
 import { ActionStatement } from "./ActionStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class FunctionCall extends ActionStatement {
   /**
    * Constructor

--- a/libraries/search-javascript/lib/testcase/statements/action/Getter.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/Getter.ts
@@ -26,9 +26,6 @@ import { Decoding } from "../Statement";
 import { ClassActionStatement } from "./ClassActionStatement";
 import { ConstructorCall } from "./ConstructorCall";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class Getter extends ClassActionStatement {
   /**
    * Constructor

--- a/libraries/search-javascript/lib/testcase/statements/action/ObjectFunctionCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ObjectFunctionCall.ts
@@ -27,9 +27,6 @@ import { Decoding, Statement } from "../Statement";
 import { ActionStatement } from "./ActionStatement";
 import { ConstantObject } from "./ConstantObject";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class ObjectFunctionCall extends ActionStatement {
   private _object: ConstantObject;
 

--- a/libraries/search-javascript/lib/testcase/statements/action/Setter.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/Setter.ts
@@ -28,9 +28,6 @@ import { ConstructorCall } from "./ConstructorCall";
 import { Getter } from "./Getter";
 import { MethodCall } from "./MethodCall";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class Setter extends ClassActionStatement {
   /**
    * Constructor

--- a/libraries/search-javascript/lib/testcase/statements/complex/ArrayStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ArrayStatement.ts
@@ -24,9 +24,6 @@ import { ContextBuilder } from "../../../testbuilding/ContextBuilder";
 import { JavaScriptTestCaseSampler } from "../../sampling/JavaScriptTestCaseSampler";
 import { Decoding, Statement } from "../Statement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class ArrayStatement extends Statement {
   private _elements: Statement[];
 

--- a/libraries/search-javascript/lib/testcase/statements/complex/ArrowFunctionStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ArrowFunctionStatement.ts
@@ -24,9 +24,6 @@ import { ContextBuilder } from "../../../testbuilding/ContextBuilder";
 import { JavaScriptTestCaseSampler } from "../../sampling/JavaScriptTestCaseSampler";
 import { Decoding, Statement } from "../Statement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class ArrowFunctionStatement extends Statement {
   private _parameters: string[];
   private _returnValue: Statement | undefined;

--- a/libraries/search-javascript/lib/testcase/statements/complex/ObjectStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ObjectStatement.ts
@@ -24,9 +24,6 @@ import { ContextBuilder } from "../../../testbuilding/ContextBuilder";
 import { JavaScriptTestCaseSampler } from "../../sampling/JavaScriptTestCaseSampler";
 import { Decoding, Statement } from "../Statement";
 
-/**
- * @author Dimitri Stallenberg
- */
 type ObjectType = {
   [key: string]: Statement | undefined;
 };

--- a/libraries/search-javascript/lib/testcase/statements/primitive/BoolStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/BoolStatement.ts
@@ -24,9 +24,6 @@ import { Statement } from "../Statement";
 
 import { PrimitiveStatement } from "./PrimitiveStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class BoolStatement extends PrimitiveStatement<boolean> {
   constructor(
     variableIdentifier: string,

--- a/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
@@ -27,8 +27,6 @@ import { PrimitiveStatement } from "./PrimitiveStatement";
 
 /**
  * Generic number class
- *
- * @author Dimitri Stallenberg
  */
 export class IntegerStatement extends PrimitiveStatement<number> {
   constructor(

--- a/libraries/search-javascript/lib/testcase/statements/primitive/NullStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/NullStatement.ts
@@ -24,9 +24,6 @@ import { Statement } from "../Statement";
 
 import { PrimitiveStatement } from "./PrimitiveStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class NullStatement extends PrimitiveStatement<boolean> {
   constructor(
     variableIdentifier: string,

--- a/libraries/search-javascript/lib/testcase/statements/primitive/NumericStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/NumericStatement.ts
@@ -27,8 +27,6 @@ import { PrimitiveStatement } from "./PrimitiveStatement";
 
 /**
  * Generic number class
- *
- * @author Dimitri Stallenberg
  */
 export class NumericStatement extends PrimitiveStatement<number> {
   constructor(

--- a/libraries/search-javascript/lib/testcase/statements/primitive/PrimitiveStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/PrimitiveStatement.ts
@@ -22,9 +22,6 @@ import { ContextBuilder } from "../../../testbuilding/ContextBuilder";
 import { JavaScriptTestCaseSampler } from "../../sampling/JavaScriptTestCaseSampler";
 import { Decoding, Statement } from "../Statement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export abstract class PrimitiveStatement<T> extends Statement {
   get value(): T {
     return this._value;

--- a/libraries/search-javascript/lib/testcase/statements/primitive/StringStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/StringStatement.ts
@@ -25,9 +25,6 @@ import { Decoding, Statement } from "../Statement";
 
 import { PrimitiveStatement } from "./PrimitiveStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class StringStatement extends PrimitiveStatement<string> {
   constructor(
     variableIdentifier: string,

--- a/libraries/search-javascript/lib/testcase/statements/primitive/UndefinedStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/UndefinedStatement.ts
@@ -24,9 +24,6 @@ import { Statement } from "../Statement";
 
 import { PrimitiveStatement } from "./PrimitiveStatement";
 
-/**
- * @author Dimitri Stallenberg
- */
 export class UndefinedStatement extends PrimitiveStatement<undefined> {
   constructor(
     variableIdentifier: string,

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
@@ -30,8 +30,6 @@ export type StateStorageOptions = {
 
 /**
  * This graphing plugin creates a listener that creates an SVG based on the generated CFG.
- *
- * @author Dimitri Stallenberg
  */
 export class StateStorageEventListenerPlugin extends EventListenerPlugin {
   private storageManager: StorageManager;

--- a/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
+++ b/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
@@ -20,8 +20,6 @@ import { JavaScriptTestCase, TreeCrossover } from "@syntest/search-javascript";
 
 /**
  * Plugin for Tree Crossover
- *
- * @author Dimitri Stallenberg
  */
 export class TreeCrossoverPlugin extends CrossoverPlugin<JavaScriptTestCase> {
   constructor() {

--- a/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
+++ b/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
@@ -27,8 +27,6 @@ import { JavaScriptArguments } from "../../JavaScriptLauncher";
 
 /**
  * Plugin for RandomSampler
- *
- * @author Dimitri Stallenberg
  */
 export class RandomSamplerPlugin extends SamplerPlugin<JavaScriptTestCase> {
   constructor() {


### PR DESCRIPTION
Authors tags don't provide much use. Multiple authors will work on a file over time, just adding more people using tags seems counter-productive. Additionally any version control system will have the capability to track who created/modified/deleted a file.