### PR TITLE
Apply TU Delft waiver

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,10 @@
-SynTest Javascript
-Copyright 2020-2021 Delft University of Technology and SynTest contributors
+SynTest Framework - SynTest JavaScript
 
-This product includes software developed at
-Delft University of Technology (http://www.tudelft.nl/).
+Delft University of Technology hereby disclaims all copyright interest in the
+“SynTest Framework” project, a set of tools for automatically generating test cases
+written by the Author(s).
+Lucas van Vliet, Dean of faculty Electrical Engineering, Mathematics, and Computer Science (EEMCS)
+
+This work is licensed under the Apache-2.0 license.
+
+Copyright 2020-2023 SynTest contributors

--- a/NOTICE.header.ts
+++ b/NOTICE.header.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-<%= YEAR %> Delft University of Technology and SynTest contributors
+ * Copyright 2020-<%= YEAR %> SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/index.ts
+++ b/libraries/analysis-javascript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/Events.ts
+++ b/libraries/analysis-javascript/lib/Events.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/Factory.ts
+++ b/libraries/analysis-javascript/lib/Factory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/RootContext.ts
+++ b/libraries/analysis-javascript/lib/RootContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/ast/AbstractSyntaxTreeFactory.ts
+++ b/libraries/analysis-javascript/lib/ast/AbstractSyntaxTreeFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/ast/defaultBabelConfig.ts
+++ b/libraries/analysis-javascript/lib/ast/defaultBabelConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/cfg/ControlFlowGraphFactory.ts
+++ b/libraries/analysis-javascript/lib/cfg/ControlFlowGraphFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/cfg/ControlFlowGraphVisitor.ts
+++ b/libraries/analysis-javascript/lib/cfg/ControlFlowGraphVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/constant/ConstantPool.ts
+++ b/libraries/analysis-javascript/lib/constant/ConstantPool.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/constant/ConstantPoolFactory.ts
+++ b/libraries/analysis-javascript/lib/constant/ConstantPoolFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/constant/ConstantPoolManager.ts
+++ b/libraries/analysis-javascript/lib/constant/ConstantPoolManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/constant/ConstantVisitor.ts
+++ b/libraries/analysis-javascript/lib/constant/ConstantVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
+++ b/libraries/analysis-javascript/lib/dependency/DependencyFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/dependency/DependencyVisitor.ts
+++ b/libraries/analysis-javascript/lib/dependency/DependencyVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/Target.ts
+++ b/libraries/analysis-javascript/lib/target/Target.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2021 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/TargetFactory.ts
+++ b/libraries/analysis-javascript/lib/target/TargetFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/TargetVisitor.ts
+++ b/libraries/analysis-javascript/lib/target/TargetVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/VisibilityType.ts
+++ b/libraries/analysis-javascript/lib/target/VisibilityType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/export/Export.ts
+++ b/libraries/analysis-javascript/lib/target/export/Export.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/target/export/ExportDefaultDeclaration.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExportDefaultDeclaration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/target/export/ExportFactory.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExportFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/export/ExportNamedDeclaration.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExportNamedDeclaration.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/target/export/ExportVisitor.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExportVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/target/export/ExpressionStatement.ts
+++ b/libraries/analysis-javascript/lib/target/export/ExpressionStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/TypeExtractor.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/TypeExtractor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/element/Element.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/element/Element.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/element/ElementVisitor.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/element/ElementVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/object/DiscoveredType.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/object/DiscoveredType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/object/ObjectVisitor.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/object/ObjectVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/relation/Relation.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/relation/Relation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/type/discovery/relation/RelationVisitor.ts
+++ b/libraries/analysis-javascript/lib/type/discovery/relation/RelationVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/Type.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/Type.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/TypeEnum.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeEnum.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/TypeModel.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeModel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/TypeModelFactory.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypeModelFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/lib/type/resolving/TypePool.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/TypePool.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/utils/diagnostics.ts
+++ b/libraries/analysis-javascript/lib/utils/diagnostics.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/lib/utils/fileSystem.ts
+++ b/libraries/analysis-javascript/lib/utils/fileSystem.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/analysis-javascript/test/AbstractSyntaxTreeGenerator.test.ts
+++ b/libraries/analysis-javascript/test/AbstractSyntaxTreeGenerator.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/AbstractSyntaxTreeVisitor.test.ts
+++ b/libraries/analysis-javascript/test/AbstractSyntaxTreeVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/cfg/ControlFlowGraphVisitor.test.ts
+++ b/libraries/analysis-javascript/test/cfg/ControlFlowGraphVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/cfg/ForControlFlowGraphVisitor.test.ts
+++ b/libraries/analysis-javascript/test/cfg/ForControlFlowGraphVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/cfg/TernaryControlFlowGraphVisitor.test.ts
+++ b/libraries/analysis-javascript/test/cfg/TernaryControlFlowGraphVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/dependency/DependencyVisitor.test.ts
+++ b/libraries/analysis-javascript/test/dependency/DependencyVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/helper.test.ts
+++ b/libraries/analysis-javascript/test/helper.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/target/TargetFactory.test.ts
+++ b/libraries/analysis-javascript/test/target/TargetFactory.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/target/TargetVisitor.test.ts
+++ b/libraries/analysis-javascript/test/target/TargetVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/target/export/ExportVisitor.test.ts
+++ b/libraries/analysis-javascript/test/target/export/ExportVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/type/ElementVisitor.test.ts
+++ b/libraries/analysis-javascript/test/type/ElementVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/type/InferenceTypeModelFactory.test.ts
+++ b/libraries/analysis-javascript/test/type/InferenceTypeModelFactory.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/analysis-javascript/test/type/RelationVisitor.test.ts
+++ b/libraries/analysis-javascript/test/type/RelationVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/ast-visitor-javascript/index.ts
+++ b/libraries/ast-visitor-javascript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/ast-visitor-javascript/lib/AbstractSyntaxTreeVisitor.ts
+++ b/libraries/ast-visitor-javascript/lib/AbstractSyntaxTreeVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/ast-visitor-javascript/lib/globalVariables.ts
+++ b/libraries/ast-visitor-javascript/lib/globalVariables.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/ast-visitor-javascript/lib/reservedKeywords.ts
+++ b/libraries/ast-visitor-javascript/lib/reservedKeywords.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/ast-visitor-javascript/test/example.test.ts
+++ b/libraries/ast-visitor-javascript/test/example.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/ast-visitor-javascript/test/helper.test.ts
+++ b/libraries/ast-visitor-javascript/test/helper.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/instrumentation-javascript/index.ts
+++ b/libraries/instrumentation-javascript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/instrumentation-javascript/lib/datastructures/InstrumentationData.ts
+++ b/libraries/instrumentation-javascript/lib/datastructures/InstrumentationData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/instrumentation-javascript/lib/datastructures/MetaData.ts
+++ b/libraries/instrumentation-javascript/lib/datastructures/MetaData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/instrumentation-javascript/lib/instrumentation/Instrumenter.ts
+++ b/libraries/instrumentation-javascript/lib/instrumentation/Instrumenter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/instrumentation-javascript/lib/instrumentation/VisitState.ts
+++ b/libraries/instrumentation-javascript/lib/instrumentation/VisitState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/instrumentation-javascript/lib/instrumentation/Visitor.ts
+++ b/libraries/instrumentation-javascript/lib/instrumentation/Visitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/instrumentation-javascript/lib/instrumentation/source-coverage.ts
+++ b/libraries/instrumentation-javascript/lib/instrumentation/source-coverage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/instrumentation-javascript/test/example.test.ts
+++ b/libraries/instrumentation-javascript/test/example.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/index.ts
+++ b/libraries/search-javascript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/criterion/BranchDistance.ts
+++ b/libraries/search-javascript/lib/criterion/BranchDistance.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/criterion/BranchDistanceVisitor.ts
+++ b/libraries/search-javascript/lib/criterion/BranchDistanceVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/search/JavaScriptExecutionResult.ts
+++ b/libraries/search-javascript/lib/search/JavaScriptExecutionResult.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/search/JavaScriptSubject.ts
+++ b/libraries/search-javascript/lib/search/JavaScriptSubject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/search/crossover/TreeCrossover.ts
+++ b/libraries/search-javascript/lib/search/crossover/TreeCrossover.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testbuilding/ContextBuilder.ts
+++ b/libraries/search-javascript/lib/testbuilding/ContextBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
+++ b/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testbuilding/JavaScriptSuiteBuilder.ts
+++ b/libraries/search-javascript/lib/testbuilding/JavaScriptSuiteBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testbuilding/assertionFunctionTemplate.ts
+++ b/libraries/search-javascript/lib/testbuilding/assertionFunctionTemplate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/JavaScriptTestCase.ts
+++ b/libraries/search-javascript/lib/testcase/JavaScriptTestCase.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/StatementPool.ts
+++ b/libraries/search-javascript/lib/testcase/StatementPool.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/execution/AssertionData.ts
+++ b/libraries/search-javascript/lib/testcase/execution/AssertionData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/execution/ExecutionInformationIntegrator.ts
+++ b/libraries/search-javascript/lib/testcase/execution/ExecutionInformationIntegrator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/execution/JavaScriptRunner.ts
+++ b/libraries/search-javascript/lib/testcase/execution/JavaScriptRunner.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/execution/SilentMochaReporter.ts
+++ b/libraries/search-javascript/lib/testcase/execution/SilentMochaReporter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/execution/TestExecutor.ts
+++ b/libraries/search-javascript/lib/testcase/execution/TestExecutor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/Generator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/Generator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/ConstantObjectGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/ConstantObjectGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/ConstructorCallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/ConstructorCallGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/FunctionCallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/FunctionCallGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/GetterGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/GetterGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/MethodCallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/MethodCallGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/ObjectFunctionCallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/ObjectFunctionCallGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/SetterGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/SetterGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/Statement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/Statement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/ActionStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ActionStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/ClassActionStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ClassActionStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/ConstantObject.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ConstantObject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/ConstructorCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ConstructorCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/FunctionCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/FunctionCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/Getter.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/Getter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/MethodCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/MethodCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/ObjectFunctionCall.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/ObjectFunctionCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/action/Setter.ts
+++ b/libraries/search-javascript/lib/testcase/statements/action/Setter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/complex/ArrayStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ArrayStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/complex/ArrowFunctionStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ArrowFunctionStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/complex/ObjectStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/complex/ObjectStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/BoolStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/BoolStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/IntegerStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/NullStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/NullStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/NumericStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/NumericStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/PrimitiveStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/PrimitiveStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/StringStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/StringStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/lib/testcase/statements/primitive/UndefinedStatement.ts
+++ b/libraries/search-javascript/lib/testcase/statements/primitive/UndefinedStatement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryDoubleEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryDoubleEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryDoubleNotEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryDoubleNotEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryGreater.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryGreater.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryGreaterOrEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryGreaterOrEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryIn.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryIn.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinarySmaller.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinarySmaller.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinarySmallerOrEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinarySmallerOrEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryTrippleEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryTrippleEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceBinaryTrippleNotEqual.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceBinaryTrippleNotEqual.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceLogicalOr.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceLogicalOr.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceStringFunctions.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceStringFunctions.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceUnaryNot.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceUnaryNot.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/BranchDistanceVisitor.test.ts
+++ b/libraries/search-javascript/test/criterion/BranchDistanceVisitor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/criterion/RandomBranchDistanceTests.test.ts
+++ b/libraries/search-javascript/test/criterion/RandomBranchDistanceTests.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/libraries/search-javascript/test/helper.test.ts
+++ b/libraries/search-javascript/test/helper.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/plugins/plugin-javascript-event-listener-state-storage/index.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorage.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorage.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageModule.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/lib/StateStorageModule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/plugins/plugin-javascript-event-listener-state-storage/test/simulation.test.ts
+++ b/plugins/plugin-javascript-event-listener-state-storage/test/simulation.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/index.ts
+++ b/tools/javascript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/JavaScriptLauncher.ts
+++ b/tools/javascript/lib/JavaScriptLauncher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest Javascript.
  *

--- a/tools/javascript/lib/JavaScriptModule.ts
+++ b/tools/javascript/lib/JavaScriptModule.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/commands/test.ts
+++ b/tools/javascript/lib/commands/test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
+++ b/tools/javascript/lib/plugins/crossover/TreeCrossoverPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
+++ b/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/workflows/DeDuplicator.ts
+++ b/tools/javascript/lib/workflows/DeDuplicator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/workflows/MetaComment.ts
+++ b/tools/javascript/lib/workflows/MetaComment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/lib/workflows/TestSplitter.ts
+++ b/tools/javascript/lib/workflows/TestSplitter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *

--- a/tools/javascript/test/example.test.ts
+++ b/tools/javascript/test/example.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Delft University of Technology and SynTest contributors
+ * Copyright 2020-2023 SynTest contributors
  *
  * This file is part of SynTest Framework - SynTest JavaScript.
  *


### PR DESCRIPTION
This PR applies the Delft University of Technology Copyright waiver and thus transverse the copyrights from the University to the SynTest Contributors.