### PR TITLE
Repair decoder undefined json bug

### DIFF
--- a/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
+++ b/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
@@ -234,9 +234,7 @@ export class JavaScriptDecoder implements Decoder<JavaScriptTestCase, string> {
           continue;
         }
 
-        // TODO dirty hack because json.parse does not allow undefined/NaN
-        // TODO undefined/NaN can happen in arrays
-        // TODO should not be within quotes
+        // Dirty hack because json.parse does not allow undefined/NaN
         stringified = stringified.replaceAll(
           /undefined(?=[^"]*(?:"[^"]*"[^"]*)*$)/g,
           "null"

--- a/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
+++ b/libraries/search-javascript/lib/testbuilding/JavaScriptDecoder.ts
@@ -17,6 +17,7 @@
  */
 
 import { ImplementationError } from "@syntest/diagnostics";
+import { getLogger, Logger } from "@syntest/logging";
 import { Decoder } from "@syntest/search";
 
 import { JavaScriptTestCase } from "../testcase/JavaScriptTestCase";
@@ -30,9 +31,11 @@ import { assertionFunction } from "./assertionFunctionTemplate";
 import { ContextBuilder } from "./ContextBuilder";
 
 export class JavaScriptDecoder implements Decoder<JavaScriptTestCase, string> {
+  protected static LOGGER: Logger;
   private targetRootDirectory: string;
 
   constructor(targetRootDirectory: string) {
+    JavaScriptDecoder.LOGGER = getLogger(JavaScriptDecoder.name);
     this.targetRootDirectory = targetRootDirectory;
   }
 
@@ -76,9 +79,10 @@ export class JavaScriptDecoder implements Decoder<JavaScriptTestCase, string> {
       }
 
       if (decodings.length === 0) {
-        throw new ImplementationError(
+        JavaScriptDecoder.LOGGER.warn(
           "No statements in test case after error reduction"
         );
+        continue;
       }
 
       const metaCommentBlock = this.generateMetaComments(testCase);
@@ -232,8 +236,15 @@ export class JavaScriptDecoder implements Decoder<JavaScriptTestCase, string> {
 
         // TODO dirty hack because json.parse does not allow undefined/NaN
         // TODO undefined/NaN can happen in arrays
-        stringified = stringified.replace("undefined", "null");
-        stringified = stringified.replace("NaN", "null");
+        // TODO should not be within quotes
+        stringified = stringified.replaceAll(
+          /undefined(?=[^"]*(?:"[^"]*"[^"]*)*$)/g,
+          "null"
+        );
+        stringified = stringified.replaceAll(
+          /NaN(?=[^"]*(?:"[^"]*"[^"]*)*$)/g,
+          "null"
+        );
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const value = JSON.parse(stringified);


### PR DESCRIPTION
When the stringified json contains a undefined or NaN value we need to replace it by null to allow for json.parse to work.
Previously we used a simple replace. Now its a regex that only replaces unquoted instances of undefined & NaN.