### PR TITLE
Allow removal of arguments

### DIFF
--- a/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
@@ -910,8 +910,9 @@ export class InferenceTypeModelFactory extends TypeModelFactory {
     originalInvolved: string[]
   ) {
     const [objectId, propertyId] = involved;
-    const [, originalProperty] = originalInvolved;
+    const [originalObject, originalProperty] = originalInvolved;
 
+    const objectElement = elementMap.get(originalObject);
     const propertyElement = elementMap.get(originalProperty);
 
     if (propertyElement === undefined) {
@@ -926,6 +927,11 @@ export class InferenceTypeModelFactory extends TypeModelFactory {
           // e.g. object[0]
           // add array type to object
           this._typeModel.addElementType(objectId, relation.id);
+
+          if (objectElement && objectElement.type === ElementType.Identifier && objectElement.name === 'arguments') {
+            // e.g. arguments[0]
+            // TODO get function parent and add the argument (impossible right now)
+          }
 
           break;
         }

--- a/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
+++ b/libraries/analysis-javascript/lib/type/resolving/InferenceTypeModelFactory.ts
@@ -928,7 +928,11 @@ export class InferenceTypeModelFactory extends TypeModelFactory {
           // add array type to object
           this._typeModel.addElementType(objectId, relation.id);
 
-          if (objectElement && objectElement.type === ElementType.Identifier && objectElement.name === 'arguments') {
+          if (
+            objectElement &&
+            objectElement.type === ElementType.Identifier &&
+            objectElement.name === "arguments"
+          ) {
             // e.g. arguments[0]
             // TODO get function parent and add the argument (impossible right now)
           }

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptRandomSampler.ts
@@ -71,7 +71,10 @@ export class JavaScriptRandomSampler extends JavaScriptTestCaseSampler {
     stringAlphabet: string,
     stringMaxLength: number,
     deltaMutationProbability: number,
-    exploreIllegalValues: boolean
+    exploreIllegalValues: boolean,
+    addRemoveArgumentProbability: number,
+    addArgumentProbability: number,
+    removeArgumentProbability: number
   ) {
     super(
       subject,
@@ -89,7 +92,10 @@ export class JavaScriptRandomSampler extends JavaScriptTestCaseSampler {
       stringAlphabet,
       stringMaxLength,
       deltaMutationProbability,
-      exploreIllegalValues
+      exploreIllegalValues,
+      addRemoveArgumentProbability,
+      addArgumentProbability,
+      removeArgumentProbability
     );
   }
 

--- a/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/JavaScriptTestCaseSampler.ts
@@ -78,6 +78,10 @@ export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScri
 
   private _exploreIllegalValues: boolean;
 
+  protected _addRemoveArgumentProbability: number;
+  protected _addArgumentProbability: number;
+  protected _removeArgumentProbability: number;
+
   private _statementPool: StatementPool | null;
 
   private _functionCallGenerator: FunctionCallGenerator;
@@ -106,7 +110,10 @@ export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScri
     stringAlphabet: string,
     stringMaxLength: number,
     deltaMutationProbability: number,
-    exploreIllegalValues: boolean
+    exploreIllegalValues: boolean,
+    addRemoveArgumentProbability: number,
+    addArgumentProbability: number,
+    removeArgumentProbability: number
   ) {
     super(subject);
     this._constantPoolManager = constantPoolManager;
@@ -127,6 +134,10 @@ export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScri
     this._stringMaxLength = stringMaxLength;
     this._deltaMutationProbability = deltaMutationProbability;
     this._exploreIllegalValues = exploreIllegalValues;
+
+    this._addRemoveArgumentProbability = addRemoveArgumentProbability;
+    this._addArgumentProbability = addArgumentProbability;
+    this._removeArgumentProbability = removeArgumentProbability;
   }
 
   get rootContext() {
@@ -140,43 +151,64 @@ export abstract class JavaScriptTestCaseSampler extends EncodingSampler<JavaScri
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._constructorCallGenerator = new ConstructorCallGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._methodCallGenerator = new MethodCallGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._getterGenerator = new GetterGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._setterGenerator = new SetterGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._constantObjectGenerator = new ConstantObjectGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
     this._objectFunctionCallGenerator = new ObjectFunctionCallGenerator(
       this,
       rootContext,
       this._statementPoolEnabled,
-      this._statementPoolProbability
+      this._statementPoolProbability,
+      this._addRemoveArgumentProbability,
+      this._addArgumentProbability,
+      this._removeArgumentProbability
     );
   }
 

--- a/libraries/search-javascript/lib/testcase/sampling/generators/Generator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/Generator.ts
@@ -28,16 +28,26 @@ export abstract class Generator<S extends Statement> {
   protected _statementPoolEnabled: boolean;
   protected _statementPoolProbability: number;
 
+  protected _addRemoveArgumentProbability: number;
+  protected _addArgumentProbability: number;
+  protected _removeArgumentProbability: number;
+
   constructor(
     sampler: JavaScriptTestCaseSampler,
     rootContext: RootContext,
     statementPoolEnabled: boolean,
-    statementPoolProbability: number
+    statementPoolProbability: number,
+    addRemoveArgumentProbability: number,
+    addArgumentProbability: number,
+    removeArgumentProbability: number
   ) {
     this._sampler = sampler;
     this._rootContext = rootContext;
     this._statementPoolEnabled = statementPoolEnabled;
     this._statementPoolProbability = statementPoolProbability;
+    this._addRemoveArgumentProbability = addRemoveArgumentProbability;
+    this._addArgumentProbability = addArgumentProbability;
+    this._removeArgumentProbability = removeArgumentProbability;
   }
 
   abstract generate(

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
@@ -51,7 +51,7 @@ export abstract class CallGenerator<S extends Statement> extends Generator<S> {
       // remove args
       for (let index = 0; index < arguments_.length; index++) {
         if (!prng.nextBoolean(this._removeArgumentProbability)) {
-          break
+          break;
         }
         arguments_.pop();
       }
@@ -59,11 +59,9 @@ export abstract class CallGenerator<S extends Statement> extends Generator<S> {
       // add args
       for (let index = 0; index < 10; index++) {
         if (!prng.nextBoolean(this._addArgumentProbability)) {
-          break
+          break;
         }
-        arguments_.push(
-          this.sampler.sampleArgument(depth + 1, "anon", "anon")
-        );
+        arguments_.push(this.sampler.sampleArgument(depth + 1, "anon", "anon"));
       }
     }
 

--- a/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
+++ b/libraries/search-javascript/lib/testcase/sampling/generators/action/CallGenerator.ts
@@ -46,10 +46,24 @@ export abstract class CallGenerator<S extends Statement> extends Generator<S> {
       }
     }
 
-    for (let index = 0; index < 10; index++) {
-      if (prng.nextBoolean(0.05)) {
-        // TODO make this a config parameter
-        arguments_.push(this.sampler.sampleArgument(depth + 1, "anon", "anon"));
+    // 50/50 to either maybe remove or add an argument
+    if (prng.nextBoolean(this._addRemoveArgumentProbability)) {
+      // remove args
+      for (let index = 0; index < arguments_.length; index++) {
+        if (!prng.nextBoolean(this._removeArgumentProbability)) {
+          break
+        }
+        arguments_.pop();
+      }
+    } else {
+      // add args
+      for (let index = 0; index < 10; index++) {
+        if (!prng.nextBoolean(this._addArgumentProbability)) {
+          break
+        }
+        arguments_.push(
+          this.sampler.sampleArgument(depth + 1, "anon", "anon")
+        );
       }
     }
 

--- a/tools/javascript/lib/JavaScriptLauncher.ts
+++ b/tools/javascript/lib/JavaScriptLauncher.ts
@@ -788,7 +788,10 @@ export class JavaScriptLauncher extends Launcher<JavaScriptArguments> {
       this.arguments_.stringAlphabet,
       this.arguments_.stringMaxLength,
       this.arguments_.deltaMutationProbability,
-      this.arguments_.exploreIllegalValues
+      this.arguments_.exploreIllegalValues,
+      this.arguments_.addRemoveArgumentProbability,
+      this.arguments_.addArgumentProbability,
+      this.arguments_.removeArgumentProbability
     );
     sampler.rootContext = rootContext;
 

--- a/tools/javascript/lib/commands/test.ts
+++ b/tools/javascript/lib/commands/test.ts
@@ -121,6 +121,36 @@ export function getTestCommand(
     type: "number",
   });
 
+  options.set("add-remove-argument-probability", {
+    alias: [],
+    default: 0.5,
+    description:
+      "Probability to maybe add an argument as oposed to maybe remove one.",
+    group: samplingGroup,
+    hidden: false,
+    type: "number",
+  });
+
+  options.set("add-argument-probability", {
+    alias: [],
+    default: 0.1,
+    description:
+      "Probability to add one extra anonymous argument (probability to add two args is equal to probablity squared, etc.) (maximum of 10).",
+    group: samplingGroup,
+    hidden: false,
+    type: "number",
+  });
+
+  options.set("remove-argument-probability", {
+    alias: [],
+    default: 0.1,
+    description:
+      "Probability to remove an argument (probability to remove two args is equal to probablity squared, etc.).",
+    group: samplingGroup,
+    hidden: false,
+    type: "number",
+  });
+
   options.set("execution-timeout", {
     alias: [],
     default: 2000,

--- a/tools/javascript/lib/commands/test.ts
+++ b/tools/javascript/lib/commands/test.ts
@@ -217,6 +217,11 @@ export type TestCommandOptions = {
   typePoolProbability: number;
   statementPool: boolean;
   statementPoolProbability: number;
+
+  addRemoveArgumentProbability: number;
+  addArgumentProbability: number;
+  removeArgumentProbability: number;
+
   executionTimeout: number;
   testTimeout: number;
 

--- a/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
+++ b/tools/javascript/lib/plugins/sampler/RandomSamplerPlugin.ts
@@ -54,7 +54,10 @@ export class RandomSamplerPlugin extends SamplerPlugin<JavaScriptTestCase> {
       (<JavaScriptArguments>(<unknown>this.args)).stringAlphabet,
       (<JavaScriptArguments>(<unknown>this.args)).stringMaxLength,
       (<JavaScriptArguments>(<unknown>this.args)).deltaMutationProbability,
-      (<JavaScriptArguments>(<unknown>this.args)).exploreIllegalValues
+      (<JavaScriptArguments>(<unknown>this.args)).exploreIllegalValues,
+      (<JavaScriptArguments>(<unknown>this.args)).addRemoveArgumentProbability,
+      (<JavaScriptArguments>(<unknown>this.args)).addArgumentProbability,
+      (<JavaScriptArguments>(<unknown>this.args)).removeArgumentProbability
     );
   }
 


### PR DESCRIPTION
Next to adding anonymous arguments (even though the function description specified less), it is now possible for arguments to removed (even though the function description specified more).

This is usefull for example when dealing with arguments with default values.